### PR TITLE
Add upper bound to prevent usage of NumPy 2.

### DIFF
--- a/conda/recipes/versions.yaml
+++ b/conda/recipes/versions.yaml
@@ -11,7 +11,7 @@ nccl_version:
 numba_version:
   - '>=0.57'
 numpy_version:
-  - '>=1.21'
+  - '>=1.23,<2.0a0'
 nvtx_version:
   - '>=0.2.1,<0.3'
 ucx_version:


### PR DESCRIPTION
NumPy 2 is expected to be released in the near future. For the RAPIDS 24.04 release, we will pin to `numpy>=1.23,<2.0a0`. This PR adds an upper bound to affected RAPIDS repositories.

xref: https://github.com/rapidsai/build-planning/issues/29